### PR TITLE
[flow] Update typing for idx

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,15 @@
-#!/bin/sh
-. "$(dirname "$0")/_/husky.sh"
+#!/usr/bin/env sh
+. "$(dirname -- "$0")/_/husky.sh"
 
-npx pretty-quick --staged
+# Copied from https://prettier.io/docs/en/precommit.html#option-6-shell-script
+
+FILES=$(git diff --cached --name-only --diff-filter=ACMR | sed 's| |\\ |g')
+[ -z "$FILES" ] && exit 0
+
+# Prettify all selected files
+echo "$FILES" | xargs ./node_modules/.bin/prettier --ignore-unknown --write
+
+# Add back the modified/prettified files to staging
+echo "$FILES" | xargs git add
+
+exit 0

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "hermes-eslint": "^0.13.1",
     "husky": "^8.0.3",
     "lerna": "^7.1.1",
-    "prettier": "^2.8.8",
+    "prettier": "^3.0.0",
     "pretty-quick": "^3.1.3"
   },
   "resolutions": {

--- a/packages/idx/.flowconfig
+++ b/packages/idx/.flowconfig
@@ -7,5 +7,7 @@
 [lints]
 
 [options]
+conditional_type=true
+mapped_type=true
 
 [strict]

--- a/packages/idx/package.json
+++ b/packages/idx/package.json
@@ -28,7 +28,7 @@
     "@babel/preset-env": "^7.21.4",
     "@babel/preset-typescript": "^7.21.4",
     "babel-jest": "^29.5.0",
-    "flow-bin": "^0.210.1",
+    "flow-bin": "^0.211.0",
     "jest": "^29.5.0",
     "typescript": "^5.0.4"
   },

--- a/packages/idx/src/idx.js.flow
+++ b/packages/idx/src/idx.js.flow
@@ -7,4 +7,34 @@
  * @flow strict
  */
 
-declare module.exports: $Facebookism$Idx;
+declare opaque type DeepRequiredArray<+T>: $ReadOnlyArray<
+  DeepRequired<$NonMaybeType<T>>,
+>;
+
+declare opaque type DeepRequiredObject<+T: interface {}>: Required<{
+  +[K in keyof T]: DeepRequired<T[K]>,
+}>;
+
+declare opaque type DeepRequired<T>: T extends empty
+  ? $FlowFixMe // If something can pass empty, it's already unsafe
+  : T extends $ReadOnlyArray<infer V>
+  ? DeepRequiredArray<V>
+  : T extends (...$ReadOnlyArray<empty>) => mixed
+  ? T
+  : T extends interface {}
+  ? DeepRequiredObject<T>
+  : $NonMaybeType<T>;
+
+type UnboxDeepRequired<T> = T extends DeepRequired<infer V> ? V : T;
+
+/**
+ * @see https://github.com/facebook/idx
+ *
+ * If you entered the file with the hope to understand why something doesn't
+ * type check, you should stop, and migrate your code away from idx first.
+ * idx is deprecated, and you should always use optional chaining instead.
+ */
+declare module.exports: <T1, T2>(
+  prop: T1,
+  accessor: (prop: $NonMaybeType<DeepRequired<T1>>) => T2,
+) => ?UnboxDeepRequired<T2>;

--- a/yarn.lock
+++ b/yarn.lock
@@ -3175,10 +3175,10 @@ flatted@^3.1.0:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.2.7.tgz#609f39207cb614b89d0765b477cb2d437fbf9787"
   integrity sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==
 
-flow-bin@^0.210.1:
-  version "0.210.1"
-  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.210.1.tgz#6a1bfce86a220eb355c0e4ec8614af7b4404da43"
-  integrity sha512-7GRivQiVBlDAIb4lGvePYJ7x8AIk/dpFLuZW3PxigcGSXMHVMKUY0qReykES2OK/B16sqJMeDV7OKHmAFut+qQ==
+flow-bin@^0.211.0:
+  version "0.211.0"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.211.0.tgz#63b1317dec690989cd386016253506d4d62dbc0f"
+  integrity sha512-zgHi0QfggHPK86NqNm2eHJo0rXlfnog8SpxjCtBBTEwpalyuk1DrzMe4Z6geq5ibXmo3MwPbFNC0FxXybgiJ6A==
 
 follow-redirects@^1.15.0:
   version "1.15.2"
@@ -5469,10 +5469,10 @@ prelude-ls@^1.2.1:
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.2.1.tgz#debc6489d7a6e6b0e7611888cec880337d316396"
   integrity sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==
 
-prettier@^2.8.8:
-  version "2.8.8"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.8.8.tgz#e8c5d7e98a4305ffe3de2e1fc4aca1a71c28b1da"
-  integrity sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==
+prettier@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-3.0.0.tgz#e7b19f691245a21d618c68bc54dc06122f6105ae"
+  integrity sha512-zBf5eHpwHOGPC47h0zrPyNn+eAEIdEzfywMoYn2XPi0P44Zp0tSq64rq0xAREh4auw2cJZHo9QUob+NqCQky4g==
 
 pretty-format@^29.5.0:
   version "29.5.0"


### PR DESCRIPTION
In this PR, I switched the idx typing from a special cased flow builtin to a userland defined type powered by conditional and mapped type, similar to the TypeScript type definition provided.

Some notes on typing tricks:

- I used the trick of opaque type to better preserve the type application structure, so that they can be reliably unboxed in the `UnboxDeepRequired` type.
- I added the case for function types before `interface {}`, because function type is a subtype of `interface {}`...


Notes on the prettier change:

- We need to update to Prettier 3 to support the new flow syntax.
- `pretty-quick` doesn't work on Prettier 3, so I copied some bash script from prettier website instead.